### PR TITLE
Settings: Make 'Google Play system update' unclickable

### DIFF
--- a/res/xml/firmware_version.xml
+++ b/res/xml/firmware_version.xml
@@ -65,9 +65,8 @@
     <Preference
         android:key="module_version"
         android:title="@string/module_version"
-        android:summary="@string/summary_placeholder"
-        settings:enableCopying="true"
-        settings:controller="com.android.settings.deviceinfo.firmwareversion.MainlineModuleVersionPreferenceController"/>
+        android:summary="13"
+        settings:enableCopying="true"/>
 
     <!-- Baseband -->
     <Preference


### PR DESCRIPTION
* Its misdirecting now and also crashes.