### PR TITLE
Settings: Add FastCharge preference into Battery settings

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -131,6 +131,7 @@ android_library {
         "kotlin-stdlib",
         "kotlinx_coroutines_android",
         "kotlinx_coroutines",
+        "vendor.lineage.fastcharge-V1.0-java",
     ],
 
     plugins: ["androidx.room_room-compiler-plugin"],

--- a/res/values/droidx_strings.xml
+++ b/res/values/droidx_strings.xml
@@ -62,6 +62,10 @@
     <!-- Warning message for the sd card setup -->
     <string name="storage_warning_internal">Warning: This option may not work properly or lead to data loss and is therefore not recommended!</string>
 
+    <!-- FastCharge feature -->
+    <string name="fast_charging_title">Fast charging</string>
+    <string name="fast_charging_summary">Disable to reduce the heat produced by the device while charging or to extend the lifespan of the battery</string>
+
     <!-- Charging control settings -->
     <string name="charging_control_title">Charging control</string>
     <string name="charging_control_summary">Customize charging schedule and limits for battery</string>

--- a/res/xml/power_usage_summary.xml
+++ b/res/xml/power_usage_summary.xml
@@ -69,6 +69,12 @@
         android:summary="@string/charging_control_summary"
         android:fragment="com.android.settings.lineage.health.ChargingControlSettings"
         settings:controller="com.android.settings.lineage.health.ChargingControlPreferenceController" />
+        
+    <SwitchPreference
+        android:key="fast_charging"
+        android:title="@string/fast_charging_title"
+        android:summary="@string/fast_charging_summary"
+        settings:controller="com.android.settings.fuelgauge.FastChargingPreferenceController"/>
 
     <com.android.settingslib.widget.FooterPreference
         android:key="power_usage_footer"

--- a/src/com/android/settings/fuelgauge/FastChargingPreferenceController.java
+++ b/src/com/android/settings/fuelgauge/FastChargingPreferenceController.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2021 The LineageOS Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.fuelgauge;
+
+import android.content.Context;
+import android.os.RemoteException;
+import android.util.Log;
+
+import androidx.preference.Preference;
+import androidx.preference.SwitchPreference;
+
+import com.android.settings.core.BasePreferenceController;
+
+import vendor.lineage.fastcharge.V1_0.IFastCharge;
+
+import java.util.NoSuchElementException;
+
+/**
+ * Controller to change and update the fast charging toggle
+ */
+public class FastChargingPreferenceController extends BasePreferenceController
+        implements Preference.OnPreferenceChangeListener {
+
+    private static final String KEY_FAST_CHARGING = "fast_charging";
+    private static final String TAG = "FastChargingPreferenceController";
+
+    private IFastCharge mFastCharge = null;
+
+    public FastChargingPreferenceController(Context context) {
+        super(context, KEY_FAST_CHARGING);
+        try {
+            mFastCharge = IFastCharge.getService();
+        } catch (NoSuchElementException | RemoteException e) {
+            Log.e(TAG, "Failed to get IFastCharge interface", e);
+        }
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mFastCharge != null ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        super.updateState(preference);
+        boolean fastChargingEnabled = false;
+
+        try {
+            fastChargingEnabled = mFastCharge.isEnabled();
+        } catch (RemoteException e) {
+            Log.e(TAG, "isEnabled failed", e);
+        }
+
+        ((SwitchPreference) preference).setChecked(fastChargingEnabled);
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        final boolean shouldEnableFastCharging = (Boolean) newValue;
+
+        try {
+            mFastCharge.setEnabled(shouldEnableFastCharging);
+            updateState(preference);
+        } catch (RemoteException e) {
+            Log.e(TAG, "setEnabled failed", e);
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
 * Several OEMs let the user decide whether to enable or disable quick charging technology when using a quickcharge charger. Samsung, for example, exposes a sysfs node to disable it at will, depending on what the user sets in battery settings UI.

 * Disabling fast charge may be useful for reducing the heat produced by the device while charging, or for extending the lifespan of the battery.

 * This commit introduces a switch preference for disabling fastcharge on devices that support said feature.

Change-Id: I7dd09d357e9bd555a8efeaf9ee191e52b9f2d151